### PR TITLE
tools: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+-   repo: git@github.com:pre-commit/pre-commit-hooks
+    sha: v0.9.3
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-json
+    -   id: check-yaml
+    -   id: check-merge-conflict
+    -   id: detect-private-key
+    -   id: check-case-conflict
+    -   id: check-added-large-files
+
+- repo: git://github.com/dnephin/pre-commit-golang
+  sha: v0.2
+  hooks:
+    - id: go-fmt
+    - id: go-vet
+    - id: go-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-added-large-files
 
 - repo: git://github.com/dnephin/pre-commit-golang
-  sha: v0.2
+  sha: 823c25f40e37d52765b6469de6df94c08e678784
   hooks:
     - id: go-fmt
     - id: go-vet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ ikdc <ikdc@mit.edu> is the current maintainer.
 
 # Style
 
-Ensure that neither `gofmt` nor `golint` complains about your code.  For
-non-Go code, make sure it is well-formatted according to your best
+Ensure that none of `gofmt`, `govet`, `golint` complains about your code.
+For non-Go code, make sure it is well-formatted according to your best
 judgment.  Please spell-check your comments.  In addition, try to wrap
 lines of code to 80 characters.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ ikdc <ikdc@mit.edu> is the current maintainer.
 
 # Style
 
-Ensure that none of `gofmt`, `govet`, `golint` complains about your code.
+Ensure that none of `gofmt`, `go vet`, `golint` complains about your code.
 For non-Go code, make sure it is well-formatted according to your best
 judgment.  Please spell-check your comments.  In addition, try to wrap
 lines of code to 80 characters.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,10 @@ Ensure that neither `gofmt` nor `golint` complains about your code.  For
 non-Go code, make sure it is well-formatted according to your best
 judgment.  Please spell-check your comments.  In addition, try to wrap
 lines of code to 80 characters.
+
+
+You can use [pre-commit](http://pre-commit.com/) to verify that your code
+passes `gofmt`, `golint`, and `go vet`'s muster and a few other checks.
+To install `pre-commit`, follow the instructions there or run
+`pip install pre-commit` or `brew install pre-commit`; then add them to
+your local git config with `pre-commit install`.


### PR DESCRIPTION
Add pre-commit hooks to automatically run `go fmt`, `golint`, etc. Also check for private keys, large files, files with trailing whitespace, etc.