### PR TITLE
Make health check fail on timeout or http error

### DIFF
--- a/demo/main/demo.go
+++ b/demo/main/demo.go
@@ -43,7 +43,7 @@ func startChecker(mm *maglev.Table, service string, info *serviceInfo) {
 			close(backend.Unhealthy)
 			mm.Remove(backend)
 		},
-		100*time.Millisecond, 500*time.Millisecond, quit)
+		100*time.Millisecond, 400*time.Millisecond, 500*time.Millisecond, quit)
 }
 
 func main() {

--- a/health/health.go
+++ b/health/health.go
@@ -86,14 +86,20 @@ func check(
 
 // health checks the given health service
 func health(healthService string) bool {
-	resp, _ := http.Get(healthService)
-	bytes, _ := ioutil.ReadAll(resp.Body)
+	const timeout = time.Duration(3 * time.Second)
 
-	resp.Body.Close()
+	client := http.Client{
+		Timeout: timeout,
+	}
 
-	if resp == nil {
+	resp, err := client.Get(healthService)
+	// Check if timeout or HTTP error
+	if resp == nil && err != nil {
 		return false
 	}
+
+	bytes, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
 
 	if strings.Contains(string(bytes), "healthy") {
 		return true

--- a/lookup/main/lookup.go
+++ b/lookup/main/lookup.go
@@ -67,7 +67,7 @@ func AddBackend(service string, ip []byte) {
 			close(backend.Unhealthy)
 			g.maglev.Remove(backend)
 		},
-		100*time.Millisecond, 500*time.Millisecond, quit)
+		100*time.Millisecond, 400*time.Millisecond, 500*time.Millisecond, quit)
 	g.servicesLock.Lock()
 	defer g.servicesLock.Unlock()
 	g.services[newService] = info


### PR DESCRIPTION
Added a timeout for the http.Get. I also added a check for if there is an error, which might be unnecessary, so remove at your call. 

Testing:

Set timeout to 1 nanoseconds; servers all report failed correctly. Set timeout to 3 seconds, all servers healthy.