### PR TITLE
Fix crash when Spike is unable to reach backend

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -87,13 +87,13 @@ func check(
 // health checks the given health service
 func health(healthService string) bool {
 	resp, _ := http.Get(healthService)
-	bytes, _ := ioutil.ReadAll(resp.Body)
-
-	resp.Body.Close()
 
 	if resp == nil {
 		return false
 	}
+
+	bytes, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
 
 	if strings.Contains(string(bytes), "healthy") {
 		return true


### PR DESCRIPTION
It previously crashed because we were trying to read data from the response before checking that it isn't nil.